### PR TITLE
Detect faulty machines and remove from machine pool

### DIFF
--- a/src/bin/server/main.rs
+++ b/src/bin/server/main.rs
@@ -244,6 +244,10 @@ struct MachineStatus {
 
     /// What job it is running, if any.
     running: Option<u64>,
+
+    /// The number of failures since the machine's class was sent or a successful job. If the
+    /// machine experiences too many consecutive failures, it will be moved to a different class.
+    failures: usize,
 }
 
 /// Information about a job run by the server.

--- a/src/bin/server/request.rs
+++ b/src/bin/server/request.rs
@@ -226,6 +226,7 @@ impl Server {
                         MachineStatus {
                             class,
                             running: running_job,
+                            failures: 0,
                         },
                     );
 

--- a/src/bin/server/snapshot.rs
+++ b/src/bin/server/snapshot.rs
@@ -363,6 +363,7 @@ impl Server {
                     MachineStatus {
                         class: status.class,
                         running: None,
+                        failures: 0,
                     },
                 )
             })


### PR DESCRIPTION
If a machine has 4 consecutive machine failures, remove it from its machine pool by moving it a new class with the suffix "-broken". The user can then do whatever is needed and move the machine back to its pool.

@BijanT Would appreciate your thoughts.