### PR TITLE
Add support for reading compressed log files

### DIFF
--- a/src/bin/client/cli.rs
+++ b/src/bin/client/cli.rs
@@ -260,7 +260,11 @@ pub(crate) fn build() -> clap::App<'static, 'static> {
                 (@arg TAIL: -t --tail conflicts_with[LESS]
                  "Pass the log path to `tail -f`")
                 (@arg R: -R requires[LESS]
-                 "Pass the -R flag to less.")
+                 "Pass the -R flag to less. This prints raw escape commands, \
+                  allowing them to display properly.")
+                (@arg Z: -z requires[LESS]
+                 "Use zless for the logfile, instead of less. Helpful if you \
+                  have compressed (gzipped) the file.")
             )
 
             (@subcommand matrix =>

--- a/src/bin/client/main.rs
+++ b/src/bin/client/main.rs
@@ -466,10 +466,21 @@ fn handle_job_cmd(addr: &str, matches: &clap::ArgMatches<'_>, line: Option<u64>)
                 .map(|path| if is_err { path + ".err" } else { path })
                 .collect();
 
+            let is_compressed = sub_m.is_present("Z");
+            for p in paths.iter() {
+                if !is_compressed
+                    && !PathBuf::from(p).exists()
+                    && PathBuf::from(p.to_owned() + ".gz").exists()
+                {
+                    panic!("{} is compressed. Use -z.", p);
+                }
+            }
+
             if sub_m.is_present("LESS") {
                 #[cfg(target_family = "unix")]
                 {
-                    let mut cmd = std::process::Command::new("less");
+                    let mut cmd =
+                        std::process::Command::new(if is_compressed { "zless" } else { "less" });
                     let mut cmd = &mut cmd;
                     if sub_m.is_present("R") {
                         cmd = cmd.arg("-R");


### PR DESCRIPTION
I compress my logs sometimes because some experiments have very large output. I think in the future it would be good to add automatic support for compressing large log files to the client.